### PR TITLE
allow empty bind address

### DIFF
--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -26,7 +26,9 @@ port <%= node[:redis][:port] %>
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
+<% if !node[:redis][:bind_address] == "" %>
 bind <%= node[:redis][:bind_address] %>
+<% end %>
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout <%= node[:redis][:timeout] %>


### PR DESCRIPTION
This will allow you to not specify the bind option and listen on all interfaces.
